### PR TITLE
Allow attempts to load files that don't exist

### DIFF
--- a/src/immuconf/config.clj
+++ b/src/immuconf/config.clj
@@ -3,6 +3,7 @@
   (:require [clojure.walk :as w]
             [clojure.edn :as edn]
             [clojure.string :as s]
+            [clojure.java.io :as java.io]
             [clojure.tools.logging :as log]))
 
 (ns-unmap *ns* 'Override)
@@ -75,7 +76,9 @@
   given filename and the resulting config "
   [file]
   (try
-    [file (edn/read-string {:readers *data-readers*} (slurp file))]
+    (let [file-as-file (java.io/as-file file)]
+      (when (.exists file-as-file)
+        [file (edn/read-string {:readers *data-readers*} (slurp file-as-file))]))
     (catch Throwable t
       (throw (ex-info (format "Error loading config file: %s" file)
                       {:file file} t)))))

--- a/test/immuconf/config_test.clj
+++ b/test/immuconf/config_test.clj
@@ -52,7 +52,14 @@
   (is (cfg/load "~/fixtures/test-a.edn")))
 
 (deftest missing-files-are-allowed
-  (is (= {} (cfg/load "test/fixtures/this-file-does-not-exist.edn"))))
+  (is (= (cfg/load "test/fixtures/test-a.edn"
+                   "test/fixtures/this-file-does-not-exist.edn"
+                   "test/fixtures/test-b.edn")
+         {:a {:b {:c 1 :d 2}}})
+      "Missing files are treated as empty maps")
+  (is (= {} (cfg/load "test/fixtures/this-file-does-not-exist.edn"
+                      "test/fixtures/another-missing-file.edn"))
+      "If all files are missing, the config is an empty map"))
 
 
 

--- a/test/immuconf/config_test.clj
+++ b/test/immuconf/config_test.clj
@@ -51,6 +51,8 @@
   (System/setProperty "user.home" (str (System/getProperty "user.dir") "/test"))
   (is (cfg/load "~/fixtures/test-a.edn")))
 
+(deftest missing-files-are-allowed
+  (is (= {} (cfg/load "test/fixtures/this-file-does-not-exist.edn"))))
 
 
 


### PR DESCRIPTION
The config loading code for the application I work on looks roughly like this:

``` clojure
(->> ["resources/config.edn" "/special/prod/folder/config.edn" "/special/dev/folder/config.edn"]
     (map load-file-if-exists)
     (apply merge))
```

Rather than having different code for loading config in prod, we just load a file from a folder that will only exist in the prod environment. And there's a priority list so developers can override things locally.

I think, philosophically, this is very similar to `immuconf`. I'm hoping to switch because the tagged literals look great :) However, currently `immuconf` will throw an exception if one of the desired files doesn't exist.

So, this PR changes `load-cfg-file` so that files that don't exist are ignored. For our application, the `resources/config.edn` will always exist so that config will be used if no other files have been created.

---

One case that might need special handling is when all the desired files don't exist. In that case, the config is returned as an empty map... That's probably not desired behaviour, and I can imagine cases where that would break a user's application.
